### PR TITLE
Refactor to run mypy in docker

### DIFF
--- a/azure/azure_style.yaml
+++ b/azure/azure_style.yaml
@@ -1,6 +1,8 @@
 parameters:
   - name: REPO_NAME
     type: string
+  - name: IMAGE
+    type: string
   # The following parameters have defaults because this template could be used by repos directly
   - name: TIMEOUT
     type: number
@@ -162,6 +164,20 @@ jobs:
     timeoutInMinutes: ${{ parameters.TIMEOUT }}
     continueOnError: ${{ parameters.IGNORE_STYLE }}
     condition: ${{ parameters.MYPY }}
+    strategy:
+      matrix:
+        "u24-gcc-ompi-latest":
+          DOCKER_TAG: u24-gcc-ompi-latest
+    variables:
+      - group: Docker
+      - name: SCRITICAL_HOMEDIR
+        value: /home/scriticaluser
+      - name: DOCKER_WORKING_DIR
+        value: ${{ variables.SCRITICAL_HOMEDIR }}/repos/${{ parameters.REPO_NAME }}
+      - name: DOCKER_MOUNT_DIR
+        value: ${{ variables.SCRITICAL_HOMEDIR }}/azure/${{ parameters.REPO_NAME }}
+      - name: BASHRC
+        value: ${{ variables.SCRITICAL_HOMEDIR }}/.bashrc_scritical
     steps:
       - checkout: self
       - checkout: azure_template
@@ -169,17 +185,24 @@ jobs:
         inputs:
           versionSpec: "3.11"
       - script: |
-          cd ${{ parameters.REPO_NAME }}
-
-          pip install wheel
-          pip install mypy
-
-          # Check if the local repo has a requirements.txt file and install it if present
-          if [[ -f "requirements.txt" ]]; then
-            pip install -r requirements.txt
+          # This is a trusted build if DOCKER_USERNAME is defined
+          if [[ ! -z $(DOCKER_USERNAME) ]] ; then
+            echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_USERNAME) --password-stdin;
           fi
-
-          # Run mypy check (should pick up local config from mypy.ini or .mypy.ini if present)
-          mypy
+          # "auto" pulls the private image for trusted builds
+          if [[ "${{ parameters.IMAGE }}" == "private" ]] || [[ "${{ parameters.IMAGE }}" == "auto" && ! -z $(DOCKER_USERNAME) ]] ; then
+            export DOCKER_IMAGE=private-dev;
+          else
+            export DOCKER_IMAGE=public-dev;
+          fi
+          docker pull scritical/$DOCKER_IMAGE:$(DOCKER_TAG);
+          docker run -t -d --name app --mount "type=bind,src=$(pwd)/${{ parameters.REPO_NAME }},target=${{ variables.DOCKER_MOUNT_DIR }}" scritical/$DOCKER_IMAGE:$(DOCKER_TAG) /bin/bash;
+          docker exec app /bin/bash -c "rm -rf ${{ variables.DOCKER_WORKING_DIR }} && cp -r ${{ variables.DOCKER_MOUNT_DIR }} ${{ variables.DOCKER_WORKING_DIR }}";
+        displayName: Prepare Repository
+      - script: |
+          set -e
+          docker exec app /bin/bash -c ". ${{ variables.BASHRC }} && cd ${{ variables.DOCKER_WORKING_DIR }} && mypy"
+        displayName: Run mypy
+        condition: and(succeeded())
 
 

--- a/azure/azure_template.yaml
+++ b/azure/azure_template.yaml
@@ -116,6 +116,7 @@ stages:
       - template: azure_style.yaml
         parameters:
           REPO_NAME: ${{ parameters.REPO_NAME }}
+          IMAGE: ${{ parameters.IMAGE }}
           TIMEOUT: ${{ parameters.TIMEOUT_STYLE }}
           IGNORE_STYLE: ${{ parameters.IGNORE_STYLE }}
           BASE_FORMAT_AND_LINT: ${{ parameters.BASE_FORMAT_AND_LINT }}


### PR DESCRIPTION
## Purpose
`mypy` expects modules imported to exist during CI check, such as `mpi4py`, which in turn depends on MPI. Instead of having to install everything or write and maintain stub files, we instead run mypy in our Docker containers. This provides the added benefit that its directly checked against our dev environment.

## Expected time until merged
The dev docker containers need to be updated before (see https://github.com/scritical/docker/pull/15)

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
