### PR TITLE
Add optional PIP_INSTALL_FLAGS input to mypy workflow

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -5,6 +5,10 @@ on:
         type: number
         default: 30
         description: "Timeout for the job in minutes"
+      PIP_INSTALL_FLAGS:
+        type: string
+        default: ""
+        description: "Additional flags passed to 'pip install' (e.g. '--no-build-isolation')"
     secrets:
       BW_ACCESS_TOKEN:
         required: true
@@ -31,7 +35,7 @@ jobs:
           docker exec \
             -e AGENT_NAME="${{ runner.name }}" \
             -e BUILD_REASON="${{ github.event_name }}" \
-            app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && pip install . && mypy"
+            app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && pip install ${{ inputs.PIP_INSTALL_FLAGS }} . && mypy"
 
       - name: Docker cleanup
         uses: scritical/.github/.github/actions/docker-cleanup@main


### PR DESCRIPTION
## Purpose
Adds an optional `PIP_INSTALL_FLAGS` input to the reusable `mypy.yaml` workflow so callers can pass extra flags to the `pip install .` step.

- Motivation: PR #52 ("pip install package before running mypy") reintroduced the `pip install .` step under pip's build isolation, which breaks repos like sr-splinetoolbox whose meson + complexify build path requires `--no-build-isolation`.
- This change is backward-compatible — the input defaults to an empty string, so existing callers see no behavioral change. sr-splinetoolbox can then opt in by passing `PIP_INSTALL_FLAGS: "--no-build-isolation"`.

## Expected time until merged
Urgent — sr-splinetoolbox mypy CI is currently broken on `main`. A same-day review/merge would unblock it.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- Default path (no input passed): the interpolated command becomes `pip install  .` (extra space), functionally identical to `pip install .` — preserves existing behavior for all current callers.
- Opt-in path: caller passes `PIP_INSTALL_FLAGS: "--no-build-isolation"` and the workflow runs `pip install --no-build-isolation .`. Will be exercised end-to-end by a follow-up PR in sr-splinetoolbox once this is merged.

## Checklist

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation

_(Checklist items N/A — workflow YAML change only; no Python/Fortran/C++ code, no test surface in this repo, no docs to update.)_