### PR TITLE
Add workflow for publishing to api-docs.scritical.com

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -74,10 +74,8 @@ Docker-based documentation build and publish workflow using the `scritical/priva
 | :--- | :--- | :------ | :---------- |
 | `TIMEOUT` | number | `30` | Runtime allowed for the job, in minutes |
 | `DOCKER_TAG` | string | `u24-gcc-ompi-latest` | Tag of `scritical/private-dev` image to build inside |
-| `BUILD_SCRIPT` | string | `""` | Repo build script that compiles and installs the current source. Empty string skips this step. Mirrors `build.yaml`'s input |
-| `GCC_CONFIG` | string | `""` | Path to GCC configuration file (passed as `CONFIG_FILE` to `BUILD_SCRIPT`) |
-| `DOCS_SRC` | string | `doc` | Docs source directory (relative to repo root). Must contain a `Makefile` with an `html` target |
-| `PRE_BUILD_HOOK` | string | `""` | Optional shell command to run on the host after checkout, before `docker-setup` (e.g., `sed -i ... doc/conf.py`). Runs from the repo root |
+| `PIP_INSTALL_FLAGS` | string | `--no-build-isolation --no-deps` | Flags passed to `pip install <FLAGS> .` from the repo root. Set to empty string to skip the install step entirely (for pure-docs repos with no installable package) |
+| `DOCS_SRC` | string | `doc` | Docs source directory (relative to repo root). Must contain a `Makefile` with an `html` target that emits to `_build/html/` |
 | `ARTIFACT_NAME` | string | n/a | Name for the uploaded HTML artifact (passed through to the publish workflow). Required |
 | `PROJECT_ID` | string | n/a | URL slug under `https://api-docs.scritical.com/<PROJECT_ID>/`. Must match `^[a-z0-9-]+$` (no slashes, no uppercase, no underscores). Required |
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,6 +7,7 @@ Reusable GitHub Actions workflows for Supercritical repositories. These workflow
 | Workflow | Description |
 | :------- | :---------- |
 | `build.yaml` | Build and test code in Docker container |
+| `build-docs.yaml` | Build documentation site in Docker container and upload HTML artifact |
 | `tapenade.yaml` | Tapenade automatic differentiation checks |
 | `clang_format.yaml` | C/C++ formatting checks |
 | `fprettify.yaml` | Fortran 90 formatting checks |
@@ -55,6 +56,29 @@ Docker-based build and test workflow using the `scritical/private-dev` image wit
 | `INTEL_CONFIG` | string | `""` | Path to Intel configuration file (from repository root) |
 | `BUILD_SCRIPT` | string | `.github/build.sh` | Path to build script. Empty string skips this step |
 | `TEST_SCRIPT` | string | `.github/test.sh` | Path to test script. Empty string skips this step |
+
+**Required Secrets:**
+| Name | Description |
+| :--- | :---------- |
+| `BW_ACCESS_TOKEN` | Bitwarden access token |
+
+If these secrets are configured at the organization level, callers can use `secrets: inherit` instead of listing each secret.
+
+---
+
+### build-docs.yaml
+
+Docker-based documentation build workflow using the `scritical/private-dev` image. Runs the repo's own build script to install the current source on top of the image, then invokes `make html` from `DOCS_SRC` and uploads the rendered HTML as an artifact. The contract is tool-agnostic, the docs dir just needs a `Makefile` with an `html` target that emits to `_build/html/`. Sphinx repos already satisfy this via the conventional Sphinx Makefile; mkdocs repos can use a one-line wrapper that calls `mkdocs build --site-dir _build/html`.
+
+| Name | Type | Default | Description |
+| :--- | :--- | :------ | :---------- |
+| `TIMEOUT` | number | `30` | Runtime allowed for the job, in minutes |
+| `DOCKER_TAG` | string | `u24-gcc-ompi-latest` | Tag of `scritical/private-dev` image to build inside |
+| `GCC_CONFIG` | string | `""` | Path to GCC configuration file (passed as `CONFIG_FILE` to `BUILD_SCRIPT`) |
+| `BUILD_SCRIPT` | string | `.github/build.sh` | Repo build script that compiles and installs the current source. Mirrors `build.yaml`'s input |
+| `DOCS_SRC` | string | `doc` | Docs source directory (relative to repo root). Must contain a `Makefile` with an `html` target |
+| `PRE_BUILD_HOOK` | string | `""` | Optional shell command to run on the host after checkout, before `docker-setup` (e.g., `sed -i ... doc/conf.py`). Runs from the repo root |
+| `ARTIFACT_NAME` | string | n/a | Name for the uploaded HTML artifact (required) |
 
 **Required Secrets:**
 | Name | Description |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,7 @@ Reusable GitHub Actions workflows for Supercritical repositories. These workflow
 | Workflow | Description |
 | :------- | :---------- |
 | `build.yaml` | Build and test code in Docker container |
-| `build-docs.yaml` | Build documentation site in Docker container and upload HTML artifact |
+| `build-docs.yaml` | Build documentation site in Docker container and publish it to `api-docs.scritical.com` |
 | `tapenade.yaml` | Tapenade automatic differentiation checks |
 | `clang_format.yaml` | C/C++ formatting checks |
 | `fprettify.yaml` | Fortran 90 formatting checks |
@@ -68,17 +68,18 @@ If these secrets are configured at the organization level, callers can use `secr
 
 ### build-docs.yaml
 
-Docker-based documentation build workflow using the `scritical/private-dev` image. Runs the repo's own build script to install the current source on top of the image, then invokes `make html` from `DOCS_SRC` and uploads the rendered HTML as an artifact. The contract is tool-agnostic, the docs dir just needs a `Makefile` with an `html` target that emits to `_build/html/`. Sphinx repos already satisfy this via the conventional Sphinx Makefile; mkdocs repos can use a one-line wrapper that calls `mkdocs build --site-dir _build/html`.
+Docker-based documentation build and publish workflow using the `scritical/private-dev` image.
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
 | `TIMEOUT` | number | `30` | Runtime allowed for the job, in minutes |
 | `DOCKER_TAG` | string | `u24-gcc-ompi-latest` | Tag of `scritical/private-dev` image to build inside |
+| `BUILD_SCRIPT` | string | `""` | Repo build script that compiles and installs the current source. Empty string skips this step. Mirrors `build.yaml`'s input |
 | `GCC_CONFIG` | string | `""` | Path to GCC configuration file (passed as `CONFIG_FILE` to `BUILD_SCRIPT`) |
-| `BUILD_SCRIPT` | string | `.github/build.sh` | Repo build script that compiles and installs the current source. Mirrors `build.yaml`'s input |
 | `DOCS_SRC` | string | `doc` | Docs source directory (relative to repo root). Must contain a `Makefile` with an `html` target |
 | `PRE_BUILD_HOOK` | string | `""` | Optional shell command to run on the host after checkout, before `docker-setup` (e.g., `sed -i ... doc/conf.py`). Runs from the repo root |
-| `ARTIFACT_NAME` | string | n/a | Name for the uploaded HTML artifact (required) |
+| `ARTIFACT_NAME` | string | n/a | Name for the uploaded HTML artifact (passed through to the publish workflow). Required |
+| `PROJECT_ID` | string | n/a | URL slug under `https://api-docs.scritical.com/<PROJECT_ID>/`. Must match `^[a-z0-9-]+$` (no slashes, no uppercase, no underscores). Required |
 
 **Required Secrets:**
 | Name | Description |

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -21,14 +21,14 @@ on:
         type: string
         default: u24-gcc-ompi-latest
         description: "Tag of scritical/private-dev image to build inside"
+      BUILD_SCRIPT:
+        type: string
+        default: ""
+        description: "[optional] Repo build script that compiles and installs the current source. Empty strings skip the build step. Mirrors build.yaml's input"
       GCC_CONFIG:
         type: string
         default: ""
         description: "Path to GCC config file (passed as CONFIG_FILE to BUILD_SCRIPT). Mirrors build.yaml's input."
-      BUILD_SCRIPT:
-        type: string
-        default: ".github/build.sh"
-        description: "Repo build script that compiles and installs the current source. Mirrors build.yaml's input."
       DOCS_SRC:
         type: string
         default: doc
@@ -69,6 +69,7 @@ jobs:
           DOCKER_TAG: ${{ env.DOCKER_TAG }}
 
       - name: Install current source inside container
+        if: inputs.BUILD_SCRIPT != ''
         run: |
           docker exec \
             -e CONFIG_FILE="${{ env.CONFIG_FILE }}" \

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,0 +1,98 @@
+# Reusable workflow: build a docs site inside the scritical/private-dev
+# container. The container provides the runtime environment (compilers, MPI,
+# pre-installed sibling deps); this workflow runs the repo's own build script
+# to install the *current* source on top, then invokes `make html` from
+# DOCS_SRC. This contract is tool-agnostic — the docs dir just needs a
+# Makefile with an `html` target that emits to `_build/html/`. Both Sphinx
+# (via the conventional Sphinx Makefile) and mkdocs (via a one-line wrapper
+# Makefile that calls `mkdocs build --site-dir _build/html`) work. Upload
+# artifact + chain to
+# scritical/documentation-server/.github/workflows/publish-api-docs.yml to
+# publish to api-docs.scritical.com.
+
+on:
+  workflow_call:
+    inputs:
+      TIMEOUT:
+        type: number
+        default: 30
+        description: "Timeout for the job in minutes"
+      DOCKER_TAG:
+        type: string
+        default: u24-gcc-ompi-latest
+        description: "Tag of scritical/private-dev image to build inside"
+      GCC_CONFIG:
+        type: string
+        default: ""
+        description: "Path to GCC config file (passed as CONFIG_FILE to BUILD_SCRIPT). Mirrors build.yaml's input."
+      BUILD_SCRIPT:
+        type: string
+        default: ".github/build.sh"
+        description: "Repo build script that compiles and installs the current source. Mirrors build.yaml's input."
+      DOCS_SRC:
+        type: string
+        default: doc
+        description: "Docs source directory (relative to repo root). Must contain a Makefile with an `html` target that emits to `_build/html/`. Works for Sphinx (default Makefile) or mkdocs (one-line wrapper)."
+      PRE_BUILD_HOOK:
+        type: string
+        default: ""
+        description: "Optional shell command to run on the host after checkout, before docker-setup (e.g., 'sed -i ... doc/conf.py'). Runs from the repo root."
+      ARTIFACT_NAME:
+        type: string
+        required: true
+        description: "Name for the uploaded HTML artifact"
+    secrets:
+      BW_ACCESS_TOKEN:
+        required: true
+        description: "Bitwarden machine account access token"
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.TIMEOUT }}
+    env:
+      DOCKER_TAG: ${{ inputs.DOCKER_TAG }}
+      CONFIG_FILE: ${{ inputs.GCC_CONFIG }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Pre-build hook
+        if: inputs.PRE_BUILD_HOOK != ''
+        run: ${{ inputs.PRE_BUILD_HOOK }}
+
+      - name: Docker setup
+        uses: scritical/.github/.github/actions/docker-setup@main
+        with:
+          BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
+          DOCKER_TAG: ${{ env.DOCKER_TAG }}
+
+      - name: Install current source inside container
+        run: |
+          docker exec \
+            -e CONFIG_FILE="${{ env.CONFIG_FILE }}" \
+            app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && /bin/bash ${{ inputs.BUILD_SCRIPT }}"
+
+      - name: Build docs inside container
+        # Defer to the repo's own `make html`. The Makefile owns tool choice
+        # (Sphinx, mkdocs, ...) and any tool-specific flags. Running from
+        # DOCS_SRC matches Sphinx's source-relative include resolution and
+        # mkdocs's mkdocs.yml lookup. By convention the Makefile must emit
+        # to `_build/html/`.
+        run: |
+          docker exec app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR/${{ inputs.DOCS_SRC }} && pip install -r requirements.txt && make html"
+
+      - name: Copy rendered HTML out of container
+        run: |
+          rm -rf ./_artifact
+          docker cp "app:$DOCKER_WORKING_DIR/${{ inputs.DOCS_SRC }}/_build/html" ./_artifact
+
+      - name: Upload built artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.ARTIFACT_NAME }}
+          path: ./_artifact
+
+      - name: Docker cleanup
+        uses: scritical/.github/.github/actions/docker-cleanup@main

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -29,11 +29,15 @@ on:
       BUILD_SCRIPT:
         type: string
         default: ""
-        description: "[optional] Repo build script that compiles and installs the current source. Empty strings skip the build step. Mirrors build.yaml's input"
+        description: "[optional] Repo build script that compiles and installs the current source (heavy-compile path for Fortran/C-extension repos). Mirrors build.yaml's input. When set, the default `pip install` step is skipped, since BUILD_SCRIPT is expected to install the package itself."
       GCC_CONFIG:
         type: string
         default: ""
         description: "Path to GCC config file (passed as CONFIG_FILE to BUILD_SCRIPT). Mirrors build.yaml's input."
+      PIP_INSTALL_FLAGS:
+        type: string
+        default: "--no-build-isolation --no-deps"
+        description: "Flags passed to `pip install <FLAGS> .` from the repo root. Default is a lightweight metadata-only install that doesn't trigger a full compile and doesn't pull runtime deps (those come from the private-dev container's pre-installed env). This step is skipped automatically when BUILD_SCRIPT is set, since BUILD_SCRIPT installs the package itself."
       DOCS_SRC:
         type: string
         default: doc
@@ -83,6 +87,11 @@ jobs:
           docker exec \
             -e CONFIG_FILE="${{ env.CONFIG_FILE }}" \
             app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && /bin/bash ${{ inputs.BUILD_SCRIPT }}"
+
+      - name: Pip install current source
+        if: inputs.BUILD_SCRIPT == ''
+        run: |
+          docker exec app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && pip install ${{ inputs.PIP_INSTALL_FLAGS }} ."
 
       - name: Build docs inside container
         # Defer to the repo's own `make html`. The Makefile owns tool choice

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -2,18 +2,17 @@
 # container, then publish it to api-docs.scritical.com.
 #
 # The container provides the runtime environment (compilers, MPI, pre-installed
-# sibling deps); for repos with compiled extensions this workflow runs the
-# repo's own build script to install the *current* source on top
-# (set BUILD_SCRIPT: "" to skip for pure-Python repos), then invokes
-# `make html` from DOCS_SRC. This contract is tool-agnostic — the docs dir
-# just needs a Makefile with an `html` target that emits to `_build/html/`.
-# Both Sphinx (via the conventional Sphinx Makefile) and mkdocs (via a
-# one-line wrapper Makefile that calls `mkdocs build --site-dir _build/html`)
-# work.
+# sibling deps). This workflow does a lightweight `pip install` of the current
+# source for metadata registration (no compile, no dep resolution by default),
+# then invokes `make html` from DOCS_SRC. The contract is tool-agnostic, the
+# docs dir just needs a Makefile with an `html` target that emits to
+# `_build/html/`. Both Sphinx (via the conventional Sphinx Makefile) and mkdocs
+# (via a one-line wrapper Makefile that calls `mkdocs build --site-dir
+# _build/html`) work.
 #
 # The rendered HTML is then handed to
 # scritical/documentation-server/.github/workflows/publish-api-docs.yml,
-# which syncs the artifact to the api-docs S3 bucket.
+# which syncs the artifact to the api-docs S3 bucket and publishes to api-docs.scritical.com.
 
 on:
   workflow_call:
@@ -26,26 +25,14 @@ on:
         type: string
         default: u24-gcc-ompi-latest
         description: "Tag of scritical/private-dev image to build inside"
-      BUILD_SCRIPT:
-        type: string
-        default: ""
-        description: "[optional] Repo build script that compiles and installs the current source (heavy-compile path for Fortran/C-extension repos). Mirrors build.yaml's input. When set, the default `pip install` step is skipped, since BUILD_SCRIPT is expected to install the package itself."
-      GCC_CONFIG:
-        type: string
-        default: ""
-        description: "Path to GCC config file (passed as CONFIG_FILE to BUILD_SCRIPT). Mirrors build.yaml's input."
       PIP_INSTALL_FLAGS:
         type: string
         default: "--no-build-isolation --no-deps"
-        description: "Flags passed to `pip install <FLAGS> .` from the repo root. Default is a lightweight metadata-only install that doesn't trigger a full compile and doesn't pull runtime deps (those come from the private-dev container's pre-installed env). This step is skipped automatically when BUILD_SCRIPT is set, since BUILD_SCRIPT installs the package itself."
+        description: "Flags passed to `pip install <FLAGS> .` from the repo root. Set to empty string to skip the install step entirely (for pure-docs repos with no installable package)."
       DOCS_SRC:
         type: string
         default: doc
         description: "Docs source directory (relative to repo root). Must contain a Makefile with an `html` target that emits to `_build/html/`."
-      PRE_BUILD_HOOK:
-        type: string
-        default: ""
-        description: "Optional shell command to run on the host after checkout, before docker-setup (e.g., 'sed -i ... doc/conf.py'). Runs from the repo root."
       ARTIFACT_NAME:
         type: string
         required: true
@@ -65,15 +52,10 @@ jobs:
     timeout-minutes: ${{ inputs.TIMEOUT }}
     env:
       DOCKER_TAG: ${{ inputs.DOCKER_TAG }}
-      CONFIG_FILE: ${{ inputs.GCC_CONFIG }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Pre-build hook
-        if: inputs.PRE_BUILD_HOOK != ''
-        run: ${{ inputs.PRE_BUILD_HOOK }}
 
       - name: Docker setup
         uses: scritical/.github/.github/actions/docker-setup@main
@@ -81,15 +63,8 @@ jobs:
           BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
           DOCKER_TAG: ${{ env.DOCKER_TAG }}
 
-      - name: Install current source inside container
-        if: inputs.BUILD_SCRIPT != ''
-        run: |
-          docker exec \
-            -e CONFIG_FILE="${{ env.CONFIG_FILE }}" \
-            app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && /bin/bash ${{ inputs.BUILD_SCRIPT }}"
-
       - name: Pip install current source
-        if: inputs.BUILD_SCRIPT == ''
+        if: inputs.PIP_INSTALL_FLAGS != ''
         run: |
           docker exec app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && pip install ${{ inputs.PIP_INSTALL_FLAGS }} ."
 

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,14 +1,19 @@
 # Reusable workflow: build a docs site inside the scritical/private-dev
-# container. The container provides the runtime environment (compilers, MPI,
-# pre-installed sibling deps); this workflow runs the repo's own build script
-# to install the *current* source on top, then invokes `make html` from
-# DOCS_SRC. This contract is tool-agnostic — the docs dir just needs a
-# Makefile with an `html` target that emits to `_build/html/`. Both Sphinx
-# (via the conventional Sphinx Makefile) and mkdocs (via a one-line wrapper
-# Makefile that calls `mkdocs build --site-dir _build/html`) work. Upload
-# artifact + chain to
-# scritical/documentation-server/.github/workflows/publish-api-docs.yml to
-# publish to api-docs.scritical.com.
+# container, then publish it to api-docs.scritical.com.
+#
+# The container provides the runtime environment (compilers, MPI, pre-installed
+# sibling deps); for repos with compiled extensions this workflow runs the
+# repo's own build script to install the *current* source on top
+# (set BUILD_SCRIPT: "" to skip for pure-Python repos), then invokes
+# `make html` from DOCS_SRC. This contract is tool-agnostic — the docs dir
+# just needs a Makefile with an `html` target that emits to `_build/html/`.
+# Both Sphinx (via the conventional Sphinx Makefile) and mkdocs (via a
+# one-line wrapper Makefile that calls `mkdocs build --site-dir _build/html`)
+# work.
+#
+# The rendered HTML is then handed to
+# scritical/documentation-server/.github/workflows/publish-api-docs.yml,
+# which syncs the artifact to the api-docs S3 bucket.
 
 on:
   workflow_call:
@@ -32,7 +37,7 @@ on:
       DOCS_SRC:
         type: string
         default: doc
-        description: "Docs source directory (relative to repo root). Must contain a Makefile with an `html` target that emits to `_build/html/`. Works for Sphinx (default Makefile) or mkdocs (one-line wrapper)."
+        description: "Docs source directory (relative to repo root). Must contain a Makefile with an `html` target that emits to `_build/html/`."
       PRE_BUILD_HOOK:
         type: string
         default: ""
@@ -40,7 +45,11 @@ on:
       ARTIFACT_NAME:
         type: string
         required: true
-        description: "Name for the uploaded HTML artifact"
+        description: "Name for the uploaded HTML artifact (passed through to the downstream publish workflow)"
+      PROJECT_ID:
+        type: string
+        required: true
+        description: "URL slug under https://api-docs.scritical.com/<PROJECT_ID>/. Must match ^[a-z0-9-]+$ — no slashes, no uppercase, no underscores. Forwarded to documentation-server's publish workflow."
     secrets:
       BW_ACCESS_TOKEN:
         required: true
@@ -97,3 +106,12 @@ jobs:
 
       - name: Docker cleanup
         uses: scritical/.github/.github/actions/docker-cleanup@main
+
+  publish-docs:
+    needs: build-docs
+    uses: scritical/documentation-server/.github/workflows/publish-api-docs.yml@main
+    with:
+      project_id: ${{ inputs.PROJECT_ID }}
+      artifact_name: ${{ inputs.ARTIFACT_NAME }}
+    secrets:
+      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This repo stores the following shared repository settings/configurations/templat
     - Docker build
     - Integration testing
     - Uses `docker-setup` and `docker-cleanup`
+  - `build-docs`
+    - Documentation build (Sphinx, mkdocs, ...) via `make html`
+    - Uploads the rendered HTML as an artifact
+    - Uses `docker-setup` and `docker-cleanup`
   - `mypy`
     - Type checking
     - Uses `docker-setup` and `docker-cleanup`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo stores the following shared repository settings/configurations/templat
     - Uses `docker-setup` and `docker-cleanup`
   - `build-docs`
     - Documentation build (Sphinx, mkdocs, ...) via `make html`
-    - Uploads the rendered HTML as an artifact
+    - Publishes the rendered HTML to `api-docs.scritical.com` via `scritical/documentation-server`
     - Uses `docker-setup` and `docker-cleanup`
   - `mypy`
     - Type checking


### PR DESCRIPTION
## Purpose

Add a reusable build-docs.yaml workflow that builds a documentation site inside the scritical/private-dev container and uploads the rendered HTML as an artifact. Lets repos publish to api-docs.scritical.com (via the publish workflow in scritical/documentation-server) without duplicating Docker/dep setup.

  The contract is tool-agnostic: the docs dir just needs a Makefile with an html target that emits to _build/html/. Sphinx repos already satisfy this; mkdocs repos can use a one-line wrapper that calls mkdocs build --site-dir _build/html.
  - New .github/workflows/build-docs.yaml
  - Updated README.md to list build-docs
  - Updated .github/workflows/README.md with the new workflow's row and inputs section, matching the existing format

## Expected time until merged

Not urgent. 1 week until merge is fine.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

End-to-end runs against scritical/private-dev:u24-gcc-ompi-latest from the six consumer repos (pyaerostructure, sr-adflow, sr-baseclasses, sr-cgnsutilities, sr-complexify, sr-foilgen), each calling this workflow from their own publish-api-docs.yml on a feature-publish-api-docs branch and confirming the resulting artifact lands at https://api-docs.scritical.com/<project_id>/.

## Checklist

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
