### PR TITLE
Add PUBLISH flag to documentation workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,16 +68,20 @@ If these secrets are configured at the organization level, callers can use `secr
 
 ### build-docs.yaml
 
-Docker-based documentation build and publish workflow using the `scritical/private-dev` image.
+Docker-based documentation build and (optional) publish workflow using the `scritical/private-dev` image.
+
+Single job: builds the docs site inside the container, then — if `PUBLISH=true` — calls the `publish-to-api-docs` composite action from `scritical/documentation-server` to publish the rendered HTML.
+
+Gating lives in the caller: pass a boolean expression for `PUBLISH` (or omit it for build-only).
 
 | Name | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
+| `PROJECT_ID` | string | n/a | URL slug under `https://api-docs.scritical.com/<PROJECT_ID>/`. **Required when `PUBLISH=true`.** Must match `^[a-z0-9-]+$` (no slashes, no uppercase, no underscores) |
+| `PUBLISH` | boolean | `false` | Whether to publish after building. Typically passed as an expression. |
 | `TIMEOUT` | number | `30` | Runtime allowed for the job, in minutes |
 | `DOCKER_TAG` | string | `u24-gcc-ompi-latest` | Tag of `scritical/private-dev` image to build inside |
 | `PIP_INSTALL_FLAGS` | string | `--no-build-isolation --no-deps` | Flags passed to `pip install <FLAGS> .` from the repo root. Set to empty string to skip the install step entirely (for pure-docs repos with no installable package) |
 | `DOCS_SRC` | string | `doc` | Docs source directory (relative to repo root). Must contain a `Makefile` with an `html` target that emits to `_build/html/` |
-| `ARTIFACT_NAME` | string | n/a | Name for the uploaded HTML artifact (passed through to the publish workflow). Required |
-| `PROJECT_ID` | string | n/a | URL slug under `https://api-docs.scritical.com/<PROJECT_ID>/`. Must match `^[a-z0-9-]+$` (no slashes, no uppercase, no underscores). Required |
 
 **Required Secrets:**
 | Name | Description |

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,22 +1,22 @@
-# Reusable workflow: build a docs site inside the scritical/private-dev
-# container, then publish it to api-docs.scritical.com.
+# Reusable workflow: builds documentation site inside the scritical/private-dev
+# container, and optionally publishes it to api-docs.scritical.com.
 #
-# The container provides the runtime environment (compilers, MPI, pre-installed
-# sibling deps). This workflow does a lightweight `pip install` of the current
-# source for metadata registration (no compile, no dep resolution by default),
-# then invokes `make html` from DOCS_SRC. The contract is tool-agnostic, the
-# docs dir just needs a Makefile with an `html` target that emits to
-# `_build/html/`. Both Sphinx (via the conventional Sphinx Makefile) and mkdocs
-# (via a one-line wrapper Makefile that calls `mkdocs build --site-dir
-# _build/html`) work.
-#
-# The rendered HTML is then handed to
-# scritical/documentation-server/.github/workflows/publish-api-docs.yml,
-# which syncs the artifact to the api-docs S3 bucket and publishes to api-docs.scritical.com.
+# Build / publish gating lives in the caller's PUBLISH expression. Typical
+# pattern for "build on PRs, publish on main":
+#   PUBLISH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+# Build-only callers omit PUBLISH entirely (defaults to false).
 
 on:
   workflow_call:
     inputs:
+      PROJECT_ID:
+        type: string
+        required: false
+        description: "URL slug under https://api-docs.scritical.com/<PROJECT_ID>/. Required when PUBLISH=true. Must match ^[a-z0-9-]+$ — no slashes, no uppercase, no underscores."
+      PUBLISH:
+        type: boolean
+        default: false
+        description: "Whether to publish after building. Typically passed as a conditional expression based on github.event_name / github.ref."
       TIMEOUT:
         type: number
         default: 30
@@ -33,23 +33,18 @@ on:
         type: string
         default: doc
         description: "Docs source directory (relative to repo root). Must contain a Makefile with an `html` target that emits to `_build/html/`."
-      ARTIFACT_NAME:
-        type: string
-        required: true
-        description: "Name for the uploaded HTML artifact (passed through to the downstream publish workflow)"
-      PROJECT_ID:
-        type: string
-        required: true
-        description: "URL slug under https://api-docs.scritical.com/<PROJECT_ID>/. Must match ^[a-z0-9-]+$ — no slashes, no uppercase, no underscores. Forwarded to documentation-server's publish workflow."
     secrets:
       BW_ACCESS_TOKEN:
         required: true
         description: "Bitwarden machine account access token"
 
 jobs:
-  build-docs:
+  docs:
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.TIMEOUT }}
+    permissions:
+      id-token: write
+      contents: read
     env:
       DOCKER_TAG: ${{ inputs.DOCKER_TAG }}
 
@@ -70,32 +65,32 @@ jobs:
 
       - name: Build docs inside container
         # Defer to the repo's own `make html`. The Makefile owns tool choice
-        # (Sphinx, mkdocs, ...) and any tool-specific flags. Running from
-        # DOCS_SRC matches Sphinx's source-relative include resolution and
-        # mkdocs's mkdocs.yml lookup. By convention the Makefile must emit
-        # to `_build/html/`.
+        # (Sphinx, mkdocs, ...) and any tool-specific flags. By convention
+        # the Makefile must emit to `_build/html/`.
         run: |
           docker exec app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR/${{ inputs.DOCS_SRC }} && pip install -r requirements.txt && make html"
 
       - name: Copy rendered HTML out of container
         run: |
-          rm -rf ./_artifact
-          docker cp "app:$DOCKER_WORKING_DIR/${{ inputs.DOCS_SRC }}/_build/html" ./_artifact
+          rm -rf ./_html
+          docker cp "app:$DOCKER_WORKING_DIR/${{ inputs.DOCS_SRC }}/_build/html" ./_html
 
-      - name: Upload built artifact
-        uses: actions/upload-artifact@v7
+      - name: Validate PROJECT_ID when publishing
+        if: inputs.PUBLISH
+        run: |
+          if [ -z "${{ inputs.PROJECT_ID }}" ]; then
+            echo "::error::PROJECT_ID is required when PUBLISH=true"
+            exit 1
+          fi
+
+      - name: Publish to api-docs.scritical.com
+        if: inputs.PUBLISH
+        uses: scritical/documentation-server/.github/actions/publish-to-api-docs@main
         with:
-          name: ${{ inputs.ARTIFACT_NAME }}
-          path: ./_artifact
+          project_id: ${{ inputs.PROJECT_ID }}
+          html_dir: ./_html
+          bw_access_token: ${{ secrets.BW_ACCESS_TOKEN }}
 
       - name: Docker cleanup
+        if: always()
         uses: scritical/.github/.github/actions/docker-cleanup@main
-
-  publish-docs:
-    needs: build-docs
-    uses: scritical/documentation-server/.github/workflows/publish-api-docs.yml@main
-    with:
-      project_id: ${{ inputs.PROJECT_ID }}
-      artifact_name: ${{ inputs.ARTIFACT_NAME }}
-    secrets:
-      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}


### PR DESCRIPTION
## Purpose

Adds a PUBLISH flag to documentation workflow so that callers can skip publishing on pull requests.

## Expected time until merged

A week.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing

Test by manually running the workflow on a project repository.

## Checklist

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
