### PR TITLE
Use AWS runners

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, linux, x64, ubuntu-2404-8vcpu]
     timeout-minutes: ${{ inputs.TIMEOUT }}
     permissions:
       id-token: write

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   build-gcc:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, linux, x64, ubuntu-2404-8vcpu]
     timeout-minutes: ${{ inputs.TIMEOUT }}
     env:
       DOCKER_TAG: u24-gcc-ompi-latest
@@ -74,7 +74,7 @@ jobs:
 
 
   build-intel:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, linux, x64, ubuntu-2404-8vcpu]
     timeout-minutes: ${{ inputs.TIMEOUT }}
     env:
       DOCKER_TAG: u24-intel-impi-latest


### PR DESCRIPTION
## Purpose

Use AWS runners during the build process to prevent potential CPU architecture related issues between AWS provided runners used in scritical/docker repo vs Github provided Ubuntu runners.

## Expected time until merged

A week.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing

build.yaml has been temporarily tested on sr-MACHproviders repo:
https://github.com/scritical/sr-MACHproviders/actions/runs/26823791078/job/79085379941?pr=54

## Checklist

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
