### PR TITLE
Remove the ISORT option and enforce isort globally

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -5,10 +5,6 @@ on:
         type: boolean
         default: false
         description: "Enable McCabe complexity check (pass/fail)"
-      ISORT:
-        type: boolean
-        default: false
-        description: "Enable isort import sorting check (pass/fail)"
       TIMEOUT:
         type: number
         default: 20
@@ -69,12 +65,6 @@ jobs:
           echo "=== Ruff Linting Check ==="
           ruff check --exit-non-zero-on-fix --config $RUFF_CONFIG .
       
-      - name: isort check
-        if: inputs.ISORT
-        run: |
-          echo "=== isort Import Sorting Check ==="
-          ruff check --exit-non-zero-on-fix --select=I --config $RUFF_CONFIG .
-
       - name: McCabe complexity check
         if: inputs.MCCABE
         run: |

--- a/ruff.toml
+++ b/ruff.toml
@@ -27,7 +27,7 @@ ignore = [
     "D404", # First word of the docstring should not be "This" (Probably a good rule to follow going forward but it occurs in so many places in our code and it's not a big enough issue to warrant fixing)
 ]
 
-select = ["B", "D", "E", "F", "W"]
+select = ["B", "D", "E", "F", "I", "W"]
 
 [lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
## Purpose
This PR removes the `ISORT` flag from the `ruff` workflow and adds the `I` to the global `ruff.toml` file. 

Impact should be minimal since most, if not all, repositories are already enforcing this and have been for some time. If any repository for whatever reason cant apply `isort`, they can opt out by adding the following to the local `ruff.toml` file.

```
extend = "~/.config/ruff/ruff.toml"

[lint]
extend-ignore = ["I"]
```

Closes #54 

## Expected time until merged
1-2 days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
