### PR TITLE
Run tapenade on Java 21

### DIFF
--- a/.github/workflows/tapenade.yaml
+++ b/.github/workflows/tapenade.yaml
@@ -22,7 +22,8 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          # Matches the JRE in the scritical docker images
+          java-version: 21
 
       - name: Install and run Tapenade
         run: |


### PR DESCRIPTION
## Purpose

The scritical docker images now ship Tapenade, so this bumps the workflow to the same JRE the images install. Regenerating AD source in a container and in CI then use the same runtime. Java 8 is also long past end of life.

Verified byte-identical: adflow forward mode was regenerated under Java 8 and Java 21, giving identical output across all 30 files. This does not change any generated AD code, so it can merge before or after scritical/docker#95.

## Expected time until merged

Not urgent, quick review.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing

Any repo with `TAPENADE: true` exercises this. The workflow regenerates AD source and asserts `git diff --exit-code` is clean, so a runtime that changed the output would fail there.

## Checklist

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
