### PR TITLE
[minor] Add optional BUILD_SCRIPT input to build-docs workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -80,6 +80,7 @@ Gating lives in the caller: pass a boolean expression for `PUBLISH` (or omit it 
 | `PUBLISH` | boolean | `false` | Whether to publish after building. Typically passed as an expression. |
 | `TIMEOUT` | number | `30` | Runtime allowed for the job, in minutes |
 | `DOCKER_TAG` | string | `u24-gcc-ompi-latest` | Tag of `scritical/private-dev` image to build inside |
+| `BUILD_SCRIPT` | string | `""` | Path to a build script run inside the container before the docs build. Use for compiled packages whose autodoc needs extension modules built from source. Runs before `PIP_INSTALL_FLAGS`; leave empty to skip |
 | `PIP_INSTALL_FLAGS` | string | `--no-build-isolation --no-deps` | Flags passed to `pip install <FLAGS> .` from the repo root. Set to empty string to skip the install step entirely (for pure-docs repos with no installable package) |
 | `DOCS_SRC` | string | `doc` | Docs source directory (relative to repo root). Must contain a `Makefile` with an `html` target that emits to `_build/html/` |
 

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -25,6 +25,10 @@ on:
         type: string
         default: u24-gcc-ompi-latest
         description: "Tag of scritical/private-dev image to build inside"
+      BUILD_SCRIPT:
+        type: string
+        default: ""
+        description: "Path to a build script run inside the container before the docs build. Use for compiled packages whose autodoc needs extension modules built from source. Runs before PIP_INSTALL_FLAGS; leave empty to skip."
       PIP_INSTALL_FLAGS:
         type: string
         default: "--no-build-isolation --no-deps"
@@ -57,6 +61,11 @@ jobs:
         with:
           BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
           DOCKER_TAG: ${{ env.DOCKER_TAG }}
+
+      - name: Build inside container
+        if: inputs.BUILD_SCRIPT != ''
+        run: |
+          docker exec app /bin/bash -c ". $BASHRC && cd $DOCKER_WORKING_DIR && /bin/bash ${{ inputs.BUILD_SCRIPT }}"
 
       - name: Pip install current source
         if: inputs.PIP_INSTALL_FLAGS != ''


### PR DESCRIPTION
## Purpose

Compiled packages can't be pip installed from a bare checkout when their extension sources are generated by `make`, so autodoc has to import a build from elsewhere, and the rendered API docs drift from the source being documented.

This PR adds `BUILD_SCRIPT` that runs inside the container before the install step, mirroring the input of the same name in `build.yaml`. Defaults to empty, so existing callers are unaffected.

This PR is essentially full circle since we did discuss this in #55, which added this workflow at one point along with `PIP_INSTALL_FLAGS`. However, repos whose documented surface is a Python layer mock their compiled dependencies in `conf.py` and need no build. `sr-tacs` points autodoc at its Cython modules (`tacs.elements`, `tacs.constitutive`, `tacs.functions`), so mocking would render those pages empty, thus requiring a real build, which no `PIP_INSTALL_FLAGS` value can provide, since it governs installation rather than source generation.

Currently `sr-tacs` is currently the only repo that will use this. It could implement something similar as a local workaround, but the need is generic to any compiled package documenting its extension modules, so it belongs here rather than duplicated per repo.

## Expected time until merged
Not urgent, but scritical/sr-tacs#35 is blocked on it.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Existing consumers are unchanged — the step is skipped when the input is empty. Exercised
end to end via scritical/sr-tacs#35, which passes `.github/build_real.sh`.

## Checklist

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
