### PR TITLE
Pin pygtrie<2.6.0 in dvc_pull to fix a dvc[s3]==3.66.1 breakage

### DIFF
--- a/.github/actions/dvc_pull/action.yaml
+++ b/.github/actions/dvc_pull/action.yaml
@@ -39,15 +39,7 @@ runs:
       shell: bash
       run: |
         pip install --upgrade pip
-        # pygtrie>=2.6.0 (released after this dvc pin) removed the internal
-        # Trie._NONE_STEP attribute dvc[s3]==3.66.1 still depends on, so an
-        # unpinned install breaks `dvc pull` with:
-        #   ERROR: unexpected error - type object 'Trie' has no attribute '_NONE_STEP'
-        # Reproduced with a fresh `pip install dvc[s3]==3.66.1` (resolves
-        # pygtrie 2.6.0) and confirmed dvc 3.67.1 hits the same error, so
-        # this isn't a version bump away -- pin pygtrie until dvc's own
-        # constraints catch up. Pinned in the same install as dvc[s3] so
-        # the resolver picks a mutually-compatible set from the start.
+        # pygtrie>=2.6.0 breaks dvc 3.66.1; drop once dvc constrains it itself or upgrades to match.
         pip install 'dvc[s3]==3.66.1' 'pygtrie<2.6.0'
 
     - name: Remove 'profile' section from dvc config file

--- a/.github/actions/dvc_pull/action.yaml
+++ b/.github/actions/dvc_pull/action.yaml
@@ -39,7 +39,16 @@ runs:
       shell: bash
       run: |
         pip install --upgrade pip
-        pip install dvc[s3]==3.66.1
+        # pygtrie>=2.6.0 (released after this dvc pin) removed the internal
+        # Trie._NONE_STEP attribute dvc[s3]==3.66.1 still depends on, so an
+        # unpinned install breaks `dvc pull` with:
+        #   ERROR: unexpected error - type object 'Trie' has no attribute '_NONE_STEP'
+        # Reproduced with a fresh `pip install dvc[s3]==3.66.1` (resolves
+        # pygtrie 2.6.0) and confirmed dvc 3.67.1 hits the same error, so
+        # this isn't a version bump away -- pin pygtrie until dvc's own
+        # constraints catch up. Pinned in the same install as dvc[s3] so
+        # the resolver picks a mutually-compatible set from the start.
+        pip install 'dvc[s3]==3.66.1' 'pygtrie<2.6.0'
 
     - name: Remove 'profile' section from dvc config file
       shell: bash


### PR DESCRIPTION
## Purpose
pygtrie 2.6.0 (a recent release) removed the internal Trie._NONE_STEP attribute that dvc[s3]==3.66.1 still depends on. Since the action doesn't pin pygtrie, a fresh install now resolves 2.6.0 and dvc pull fails immediately with:

  ERROR: unexpected error - type object 'Trie' has no attribute '_NONE_STEP'

This breaks every repo using this action, unrelated to any repo's own DVC-tracked content -- reproduced with a bare `pip install dvc[s3]==3.66.1` in an isolated venv. Confirmed bumping to dvc==3.67.1 alone does NOT fix it (same fresh-install reproduction, same error) -- pygtrie 2.6.0 is broadly incompatible with current dvc, not just this pin. Verified `pip install 'dvc[s3]==3.66.1' 'pygtrie<2.6.0'` resolves pygtrie 2.5.0 and `dvc pull` succeeds.

## Expected time until merged
ASAP

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
