### PR TITLE
[patch] Drop the pygtrie<2.6.0 pin from dvc_pull

### DIFF
--- a/.github/actions/dvc_pull/action.yaml
+++ b/.github/actions/dvc_pull/action.yaml
@@ -39,8 +39,7 @@ runs:
       shell: bash
       run: |
         pip install --upgrade pip
-        # pygtrie>=2.6.0 breaks dvc 3.66.1; drop once dvc constrains it itself or upgrades to match.
-        pip install 'dvc[s3]==3.66.1' 'pygtrie<2.6.0'
+        pip install 'dvc[s3]==3.66.1'
 
     - name: Remove 'profile' section from dvc config file
       shell: bash


### PR DESCRIPTION
## Purpose

Removes the `pygtrie<2.6.0` pin added in #64. Fixed upstream by treeverse/sqltrie#98, released in sqltrie 0.11.3.

## Expected time until merged

Not urgent, a day or two.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing

`pip install 'dvc[s3]==3.66.1'` on Python 3.12 resolves to sqltrie 0.11.3 / pygtrie 2.6.1, and `PyGTrie.longest_prefix` — the call that was raising works. Confirmed locally.

## Checklist

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
